### PR TITLE
Add Community Support: cache-dit Day 1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ image.save(f"generated_image.png")
 
 ### cache-dit  
 
-[cache-dit](https://github.com/vipshop/cache-dit)(Day 1) offers Fully Cache Acceleration support for HunyuanImage-2.1 with DBCache and TaylorSeer. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/run_hunyuan_image_2.1.py) for more details.
+[cache-dit](https://github.com/vipshop/cache-dit)(Day 1) offers Fully Cache Acceleration support for HunyuanImage-2.1 with DBCache and TaylorSeer. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_hunyuan_image_2.1.py) for more details.
 
 
 ## 🔗 BibTeX

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ image.save(f"generated_image.png")
 
 ### cache-dit  
 
-[cache-dit](https://github.com/vipshop/cache-dit) offers Day 1 Fully Cache Acceleration support for HunyuanImage-2.1 with DBCache and TaylorSeer. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/run_hunyuan_image_2.1.py) for more details.
+[cache-dit](https://github.com/vipshop/cache-dit)(Day 1) offers Fully Cache Acceleration support for HunyuanImage-2.1 with DBCache and TaylorSeer. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/run_hunyuan_image_2.1.py) for more details.
 
 
 ## 🔗 BibTeX

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This repo contains PyTorch model definitions, pretrained weights and inference/s
   - [🛠️ Dependencies and Installation](#️-dependencies-and-installation)
   - [🧱 Download Pretrained Models](#-download-pretrained-models)
   - [🔑 Usage](#-usage)
+  - [🎉 Community Support](#-community-support)
   - [🔗 BibTeX](#-bibtex)
   - [Acknowledgements](#acknowledgements)
   - [Github Star History](#github-star-history)
@@ -245,6 +246,12 @@ image = pipe(
 
 image.save(f"generated_image.png")
 ```
+
+## 🎉 Community Support
+
+### cache-dit  
+
+[cache-dit](https://github.com/vipshop/cache-dit) offers Day 1 Fully Cache Acceleration support for HunyuanImage-2.1 with DBCache and TaylorSeer. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/run_hunyuan_image_2.1.py) for more details.
 
 
 ## 🔗 BibTeX

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This repo contains PyTorch model definitions, pretrained weights and inference/s
   - [🛠️ Dependencies and Installation](#️-dependencies-and-installation)
   - [🧱 Download Pretrained Models](#-download-pretrained-models)
   - [🔑 Usage](#-usage)
-  - [🎉 Community Support](#-community-support)
+  - [🎉 Community](#-community)
   - [🔗 BibTeX](#-bibtex)
   - [Acknowledgements](#acknowledgements)
   - [Github Star History](#github-star-history)
@@ -247,11 +247,9 @@ image = pipe(
 image.save(f"generated_image.png")
 ```
 
-## 🎉 Community Support
+## 🎉 Community
 
-### cache-dit  
-
-[cache-dit](https://github.com/vipshop/cache-dit)(Day 1) offers Fully Cache Acceleration support for HunyuanImage-2.1 with DBCache and TaylorSeer. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_hunyuan_image_2.1.py) for more details.
+- [cache-dit](https://github.com/vipshop/cache-dit)(Day 1) offers Fully Cache Acceleration support for HunyuanImage-2.1 with DBCache and TaylorSeer. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_hunyuan_image_2.1.py) for more details.
 
 
 ## 🔗 BibTeX


### PR DESCRIPTION
[cache-dit](https://github.com/vipshop/cache-dit)(Day 1) offers Fully Cache Acceleration support for HunyuanImage-2.1 with DBCache and TaylorSeer. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_hunyuan_image_2.1.py) for more details.

<div align="center">
  <img src=https://github.com/vipshop/cache-dit/raw/main/assets/hunyuan-image-2.1.C0_L0_Q1_fp8_w8a16_wo_NONE.png width=200px>
  <img src=https://github.com/vipshop/cache-dit/raw/main/assets/hunyuan-image-2.1.C0_L0_Q1_fp8_w8a16_wo_DBCACHE_F8B0_W8M0MC2_T1O2_R0.12_S25.png width=200px>
  <p> <b>HunyuanImage-2.1</b> | <a href="https://github.com/vipshop/cache-dit">+cache-dit</a>:1.7x↑🎉</p>
</div>

@KimbingNg @yestinl 